### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: Set up a Palo Alto Networks Cortex XSOAR connector
 og:title: Set up a Palo Alto Networks Cortex XSOAR connector - C1 docs
-og:description: Integrate your XSOAR instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
-description: C1 provides identity governance and just-in-time provisioning for Cortex XSOAR. Integrate your XSOAR instance with C1 to run user access reviews (UARs) and enable just-in-time access requests.
+og:description: "C1 provides identity governance for Cortex XSOAR. Integrate your Cortex XSOAR instance with C1 for unified visibility and governance over user access."
+description: "C1 provides identity governance for Cortex XSOAR. Integrate your Cortex XSOAR instance with C1 for unified visibility and governance over user access."
 sidebarTitle: "Palo Alto Networks Cortex XSOAR"
 ---
 
@@ -58,7 +58,7 @@ Copy the CURL Example URL. The example contains your FQDN, which forms part of y
 </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the XSOAR connector
 
@@ -111,7 +111,7 @@ Paste the API key into the **Token** field.
 Click **Save**.
 </Step>
 </Steps>
-**That's it!** The connector's label changes to **Syncing**, followed by **Connected**. You can view the logs to ensure that information is syncing.
+**Done.** The connector's label changes to **Syncing**, followed by **Connected**. You can view the logs to ensure that information is syncing.
 </Tab>
 <Tab title="Self-hosted">
 
@@ -229,7 +229,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your XSOAR connector is now pulling access data into C1.
+**Done.** Your XSOAR connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines