### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -41,7 +41,8 @@ func roleResource(ctx context.Context, role *xsoar.Role) (*v2.Resource, error) {
 		role.Name,
 		resourceTypeRole,
 		role.Id,
-		[]rs.RoleTraitOption{rs.WithRoleProfile(profile)},
+		[]rs.RoleTraitOption{},
+		rs.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -33,7 +33,9 @@ func userResource(ctx context.Context, user *xsoar.User) (*v2.Resource, error) {
 	userTraitOptions := []resource.UserTraitOption{
 		resource.WithEmail(user.Email, true),
 	}
-	var resourceOpts []resource.ResourceOption
+	resourceOpts := []resource.ResourceOption{
+		resource.WithResourceProfile(profile),
+	}
 
 	if user.Disabled {
 		resourceOpts = append(resourceOpts, resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_DISABLED, ""))
@@ -46,7 +48,7 @@ func userResource(ctx context.Context, user *xsoar.User) (*v2.Resource, error) {
 		resourceTypeUser,
 		user.Id,
 		userTraitOptions,
-		append(resourceOpts, resource.WithResourceProfile(profile))...,
+		resourceOpts...,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -32,13 +32,13 @@ func userResource(ctx context.Context, user *xsoar.User) (*v2.Resource, error) {
 
 	userTraitOptions := []resource.UserTraitOption{
 		resource.WithEmail(user.Email, true),
-		resource.WithUserProfile(profile),
 	}
+	var resourceOpts []resource.ResourceOption
 
 	if user.Disabled {
-		userTraitOptions = append(userTraitOptions, resource.WithStatus(v2.UserTrait_Status_STATUS_DISABLED))
+		resourceOpts = append(resourceOpts, resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_DISABLED, ""))
 	} else {
-		userTraitOptions = append(userTraitOptions, resource.WithStatus(v2.UserTrait_Status_STATUS_ENABLED))
+		resourceOpts = append(resourceOpts, resource.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""))
 	}
 
 	ret, err := resource.NewUserResource(
@@ -46,6 +46,7 @@ func userResource(ctx context.Context, user *xsoar.User) (*v2.Resource, error) {
 		resourceTypeUser,
 		user.Id,
 		userTraitOptions,
+		append(resourceOpts, resource.WithResourceProfile(profile))...,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
